### PR TITLE
feat: add code style prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Server AntV ![](https://badge.mcpx.dev?type=server 'MCP Server') [![npm Version](https://img.shields.io/npm/v/@antv/mcp-server-antv.svg)](https://www.npmjs.com/package/@antv/mcp-server-antv) [![smithery badge](https://smithery.ai/badge/@antvis/mcp-server-antv)](https://smithery.ai/server/@antvis/mcp-server-antv) [![npm License](https://img.shields.io/npm/l/@antv/mcp-server-antv.svg)](https://www.npmjs.com/package/@antv/mcp-server-antv)
 
-> A **Model Context Protocol (MCP)** server designed for AI development and QA that provides **AntV** documentation context and code examples using the latest APIs.  
+> A **Model Context Protocol (MCP)** server designed for AI development and QA that provides **AntV** documentation context and code examples using the latest APIs.
 
 <img width="768" alt="mcp-server-antv Technical Architecture" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*WHSOR7L8U0YAAAAATjAAAAgAemJ7AQ/fmt.webp" />
 
@@ -52,7 +52,7 @@ On Window system:
 
 ### Connect to VSCode
 
-[![Install in VSCode](https://img.shields.io/badge/Install%20in-VSCode-007ACC?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%22%3A%22mcp-server-antv%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antv%2Fmcp-server-antv%22%5D%7D)
+[![Install in VSCode](https://img.shields.io/badge/Install%20in-VSCode-2C2C2C?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%22%3A%22mcp-server-antv%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antv%2Fmcp-server-antv%22%5D%7D)
 
 Pasting the following configuration into your VSCode `~/.vscode/mcp.json` file is the recommended approach.
 
@@ -79,8 +79,8 @@ An example workflow.
 
 ## 🧰 Tools Overview
 
-| Tool                  | Functionality                                                               |
-| --------------------- | --------------------------------------------------------------------------- |
+| Tool                  | Functionality                                                                |
+| --------------------- | ---------------------------------------------------------------------------- |
 | `extract_antv_topic`  | Extract user intent, detects library (G2/G6/F2), and infers task complexity. |
 | `query_antv_document` | fetch latest documentation and code examples with context7                   |
 

--- a/__tests__/constant.spec.ts
+++ b/__tests__/constant.spec.ts
@@ -27,7 +27,8 @@ describe('context7', () => {
       name: 'G2',
       description:
         'Statistical charts, data visualization, business intelligence charts',
-      keywords: [],
+      keywords: '',
+      codeStyle: '',
     });
   });
 

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -7,25 +7,29 @@ export const ANTV_LIBRARY_META = {
     name: 'G2',
     description:
       'Statistical charts, data visualization, business intelligence charts',
-    keywords: [],
+    keywords: '',
+    codeStyle: '',
   },
   g6: {
     id: 'g6' as AntVLibrary,
     name: 'G6',
     description: 'Graph analysis, network diagrams, node-link relationships',
-    keywords: [],
+    keywords: '',
+    codeStyle: '',
   },
   l7: {
     id: 'l7' as AntVLibrary,
     name: 'L7',
     description: 'Geospatial visualization, maps, geographic data analysis',
-    keywords: [],
+    keywords: '',
+    codeStyle: '',
   },
   x6: {
     id: 'x6' as AntVLibrary,
     name: 'X6',
     description: 'Graph editing, flowcharts, diagram creation tools',
-    keywords: [],
+    keywords: '',
+    codeStyle: '',
   },
   f2: {
     id: 'f2' as AntVLibrary,
@@ -42,9 +46,12 @@ export const ANTV_LIBRARY_META = {
     - 饼图标签 (PieLabel)
     - 象形柱图 (PictorialBar)
   <components>
+  `,
+    codeStyle: `
   <convention>
-    - JSX 语法
-    - Guides, Legend, Timeline, Axis 组件必须在 Chart 组件内使用
+    - Use F2's components directly in JSX. If TypeScript errors occur, add @ts-ignore above the component
+    - Code examples are for Node environment. For React framework, import ReactCanvas from '@antv/f2-react' and use <ReactCanvas/> component instead of <Canvas/> component
+    - In F2's canvas coordinate system, Y coordinates increase from top to bottom, and X coordinates increase from left to right by default. Therefore, all values for offsetY, offsetX, x, y and similar properties are relative to the top-left corner of the canvas.
   </convention>
   `,
   },
@@ -52,7 +59,8 @@ export const ANTV_LIBRARY_META = {
     id: 's2' as AntVLibrary,
     name: 'S2',
     description: 'Table analysis, spreadsheet-like interactions, data grids',
-    keywords: [],
+    keywords: '',
+    codeStyle: '',
   },
 };
 
@@ -74,5 +82,5 @@ export function getLibraryDescription(library: AntVLibrary): string {
 }
 
 export function getLibraryKeywords(library: AntVLibrary) {
-  return ANTV_LIBRARY_META[library]?.keywords || [];
+  return ANTV_LIBRARY_META[library]?.keywords || '';
 }

--- a/src/tools/query_antv_document.ts
+++ b/src/tools/query_antv_document.ts
@@ -8,7 +8,7 @@
  */
 
 import { z } from 'zod';
-import type { AntVLibrary } from '../types';
+import type { AntVConfig, AntVLibrary } from '../types';
 import { logger, getLibraryId, fetchLibraryDocumentation } from '../utils';
 import {
   getLibraryConfig,
@@ -150,14 +150,13 @@ async function handleComplexTaskWithDocCheck(
     response += `---\n\n`;
   }
   response += `## 🎯 Task Integration Recommendations\n\n`;
-  response += generateComplexTaskSummary(args, subTaskResults);
-  response += generateIntentSpecificGuidance(args.intent, library);
+  response += generateComplexTaskSummary(subTaskResults);
+  response += generateIntentSpecificGuidance(args.intent, libraryConfig);
   response += generateFollowUpGuidance();
   return { response, hasDocumentation: hasValidDocumentation };
 }
 
 function generateComplexTaskSummary(
-  args: QueryAntVDocumentArgs,
   subTaskResults: Array<{
     task: any;
     documentation: string | null;
@@ -196,7 +195,7 @@ function generateResponse(
   response += `\n---\n\n`;
   if (context) {
     response += `## 📚 Related Documentation\n\n${context}\n\n`;
-    response += generateIntentSpecificGuidance(args.intent, library);
+    response += generateIntentSpecificGuidance(args.intent, libraryConfig);
   } else {
     response += `## ⚠️ Documentation Retrieval Failed\n\n`;
     response += `\nError: ${errorMsg}\n`;
@@ -211,21 +210,21 @@ function generateResponse(
 
 function generateIntentSpecificGuidance(
   intent: string,
-  library: string,
+  libraryConfig: AntVConfig,
 ): string {
   switch (intent) {
     case 'learn':
-      return generateLearnGuidance(library);
+      return generateLearnGuidance();
     case 'implement':
-      return generateImplementGuidance(library);
+      return generateImplementGuidance(libraryConfig);
     case 'solve':
-      return generateSolveGuidance(library);
+      return generateSolveGuidance(libraryConfig);
     default:
-      return generateDefaultGuidance(library);
+      return generateDefaultGuidance(libraryConfig);
   }
 }
 
-function generateLearnGuidance(library: string): string {
+function generateLearnGuidance(): string {
   return `## 💡 Learning Recommendations
 
 - First understand the core concepts and basic usage in the documentation
@@ -236,9 +235,9 @@ function generateLearnGuidance(library: string): string {
 `;
 }
 
-function generateImplementGuidance(library: string): string {
+function generateImplementGuidance(libraryConfig: AntVConfig): string {
   return `## 🛠️ Implementation Recommendations
-
+- Follow the code style and best practices of the library: ${libraryConfig.codeStyle}
 - Refer to example code in the documentation
 - Pay attention to required and optional parameter configurations
 - Implement basic features first, then add advanced features
@@ -247,24 +246,24 @@ function generateImplementGuidance(library: string): string {
 `;
 }
 
-function generateSolveGuidance(library: string): string {
+function generateSolveGuidance(libraryConfig: AntVConfig): string {
   return `## 🔧 Troubleshooting
 
 - Check error messages and parameter configurations
 - Compare your code with documentation examples for differences
-- Confirm ${library} version and dependency compatibility
+- Confirm ${libraryConfig.name} version and dependency compatibility
 - If problems persist, check official GitHub Issues
 
 `;
 }
 
-function generateDefaultGuidance(library: string): string {
+function generateDefaultGuidance(libraryConfig: AntVConfig): string {
   return `## 📖 Usage Recommendations
 
 - Carefully read the above documentation content
 - Practice with reference to code examples
 - Adjust relevant parameters according to requirements
-- Consult ${library} official documentation for more information
+- Consult ${libraryConfig.name} official documentation for more information
 
 `;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,11 @@
  * These libraries are used to fetch documentation and provide context for the AntV Assistant tool.
  */
 export type AntVLibrary = 'g2' | 'g6' | 'l7' | 'x6' | 'f2' | 's2';
+
+export type AntVConfig = {
+  id: AntVLibrary;
+  name: string;
+  description: string;
+  keywords: string;
+  codeStyle: string;
+};


### PR DESCRIPTION
1. 修改readme中 vscode 的 bage  ![Install in VSCode](https://img.shields.io/badge/Install%20in-VSCode-2C2C2C?style=for-the-badge&logo=visualstudiocode&logoColor=white)
2. 原先提示词中keywords拆成keywords 和code style，并将 codestyle 拼接到查询 tool 的流程中
3. 修复 keywords 类型应该为 string