### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 <img width="768" alt="mcp-server-antv Technical Architecture" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*WHSOR7L8U0YAAAAATjAAAAgAemJ7AQ/fmt.webp" />
 
+<a href="https://glama.ai/mcp/servers/@antvis/mcp-server-antv">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@antvis/mcp-server-antv/badge" alt="Server AntV MCP server" />
+</a>
+
 Supports **G2**, **G6**, and **F2** libraries for declarative visualization workflows, and **S2**, **X6**, and **L7** on the way～
 
 ## ✨ Features


### PR DESCRIPTION
This PR adds a badge for the [MCP Server AntV](https://glama.ai/mcp/servers/@antvis/mcp-server-antv) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@antvis/mcp-server-antv">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@antvis/mcp-server-antv/badge" alt="Server AntV MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.